### PR TITLE
Fix code scanning alert no. 5: CSRF protection not enabled

### DIFF
--- a/app/controllers/gitolite_public_keys_controller.rb
+++ b/app/controllers/gitolite_public_keys_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class GitolitePublicKeysController < ApplicationController
+  protect_from_forgery with: :exception
   include RedmineGitHosting::GitoliteAccessor::Methods
 
   before_action :require_login


### PR DESCRIPTION
Fixes [https://github.com/tomhub/redmine_git_hosting/security/code-scanning/5](https://github.com/tomhub/redmine_git_hosting/security/code-scanning/5)

To fix the CSRF vulnerability, we need to ensure that CSRF protection is explicitly enabled in the `GitolitePublicKeysController`. This can be done by adding a call to `protect_from_forgery with: :exception` in the controller. This method will raise an exception if an invalid CSRF token is provided, thereby preventing unauthorized actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
