### PR TITLE
Fix code scanning alert no. 6: CSRF protection not enabled

### DIFF
--- a/app/controllers/go_redirector_controller.rb
+++ b/app/controllers/go_redirector_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class GoRedirectorController < ApplicationController
+  protect_from_forgery with: :exception
   include XitoliteRepositoryFinder
 
   # prevents login action to be filtered by check_if_login_required application scope filter

--- a/app/reports/repository_contributors_stats.rb
+++ b/app/reports/repository_contributors_stats.rb
@@ -71,10 +71,10 @@ class RepositoryContributorsStats < ReportBase
       next if registered_committers.include? committer
 
       name = committer
-      previous = nil
-      while name != previous
+      loop do
         previous = name
         name = name.gsub(/<.+@.+>/, '').strip
+        break if name == previous
       end
       mail = committer[/<(.+@.+)>/, 1]
       merged << { name: name, mail: mail, commits: count, changes: changes_by_author[committer] || 0, committers: [committer] }


### PR DESCRIPTION
Fixes [https://github.com/tomhub/redmine_git_hosting/security/code-scanning/6](https://github.com/tomhub/redmine_git_hosting/security/code-scanning/6)

To fix the CSRF vulnerability, we need to ensure that CSRF protection is enabled in the `GoRedirectorController`. The best way to do this is to call `protect_from_forgery with: :exception` in the controller. This will raise an exception if an invalid CSRF token is provided, providing robust protection against CSRF attacks.

We will add the `protect_from_forgery with: :exception` line to the `GoRedirectorController` class. This change will ensure that any actions handled by this controller are protected against CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
