### PR TITLE
Fix code scanning alert no. 4: CSRF protection not enabled

### DIFF
--- a/app/controllers/download_git_revision_controller.rb
+++ b/app/controllers/download_git_revision_controller.rb
@@ -3,6 +3,8 @@
 class DownloadGitRevisionController < ApplicationController
   include XitoliteRepositoryFinder
 
+  protect_from_forgery with: :exception
+
   before_action :find_xitolite_repository
   before_action :can_download_git_revision
   before_action :set_download


### PR DESCRIPTION
Fixes [https://github.com/tomhub/redmine_git_hosting/security/code-scanning/4](https://github.com/tomhub/redmine_git_hosting/security/code-scanning/4)

To fix the CSRF vulnerability, we need to ensure that CSRF protection is explicitly enabled in the `DownloadGitRevisionController`. The best way to do this is by adding a call to `protect_from_forgery` with the `:exception` strategy, which raises an exception if an invalid CSRF token is provided. This change should be made in the `DownloadGitRevisionController` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
